### PR TITLE
fix intranet_ip start with slash error

### DIFF
--- a/src/main/java/tech/mlsql/api/controller/ClusterProxyController.scala
+++ b/src/main/java/tech/mlsql/api/controller/ClusterProxyController.scala
@@ -63,7 +63,7 @@ class ClusterProxyController extends ApplicationController with AuthModule with 
     val proxy = RestService.client(MLSQLConsoleCommandConfig.commandConfig.mlsql_cluster_url)
     var newparams = params().asScala.toMap
     val myUrl = if (MLSQLConsoleCommandConfig.commandConfig.my_url.isEmpty) {
-      s"http://${NetworkUtils.intranet_ip}:${ServiceFramwork.injector.getInstance[Settings](classOf[Settings]).get("http.port")}"
+      s"http://${NetworkUtils.intranet_ip.getHostAddress}:${ServiceFramwork.injector.getInstance[Settings](classOf[Settings]).get("http.port")}"
     } else {
       MLSQLConsoleCommandConfig.commandConfig.my_url
     }

--- a/src/main/java/tech/mlsql/api/controller/FileServer.scala
+++ b/src/main/java/tech/mlsql/api/controller/FileServer.scala
@@ -42,7 +42,7 @@ class FileServer extends ApplicationController with AuthModule {
 
     val _proxyUrl = if (clusterUrl != null && !clusterUrl.isEmpty) clusterUrl else engineUrl
     val _myUrl = if (MLSQLConsoleCommandConfig.commandConfig.my_url.isEmpty) {
-      s"http://${NetworkUtils.intranet_ip}:${ServiceFramwork.injector.getInstance[Settings](classOf[Settings]).get("http.port")}"
+      s"http://${NetworkUtils.intranet_ip.getHostAddress}:${ServiceFramwork.injector.getInstance[Settings](classOf[Settings]).get("http.port")}"
     } else {
       MLSQLConsoleCommandConfig.commandConfig.my_url
     }

--- a/src/main/java/tech/mlsql/service/EngineService.scala
+++ b/src/main/java/tech/mlsql/service/EngineService.scala
@@ -38,7 +38,7 @@ object EngineService {
 
   def save(user: MlsqlUser, name: String, url: String, option: Map[String, String]) = {
     val myUrl = if (MLSQLConsoleCommandConfig.commandConfig.my_url.isEmpty) {
-      s"http://${NetworkUtils.intranet_ip}:${ServiceFramwork.injector.getInstance[Settings](classOf[Settings]).get("http.port")}"
+      s"http://${NetworkUtils.intranet_ip.getHostAddress}:${ServiceFramwork.injector.getInstance[Settings](classOf[Settings]).get("http.port")}"
     } else {
       MLSQLConsoleCommandConfig.commandConfig.my_url
     }

--- a/src/main/java/tech/mlsql/service/RunScript.scala
+++ b/src/main/java/tech/mlsql/service/RunScript.scala
@@ -253,7 +253,7 @@ case class RunScriptResp(isSaveQuery: Boolean, isAsync: Boolean, startTime: Long
 
 object RunScript {
   val MY_URL = if (MLSQLConsoleCommandConfig.commandConfig.my_url.isEmpty) {
-    s"http://${NetworkUtils.intranet_ip}:${ServiceFramwork.injector.getInstance[Settings](classOf[Settings]).get("http.port")}"
+    s"http://${NetworkUtils.intranet_ip.getHostAddress}:${ServiceFramwork.injector.getInstance[Settings](classOf[Settings]).get("http.port")}"
   } else {
     MLSQLConsoleCommandConfig.commandConfig.my_url
   }


### PR DESCRIPTION
from the screenshot below, we can see that "intranet_ip" is start with "/", which will cause when I add engine at first time, they persist a wrong "console_url" in database which pattern is "http:///192.168****"

![image](https://user-images.githubusercontent.com/2297455/111068691-cf58d180-8504-11eb-93a0-d1c147235754.png)
